### PR TITLE
Disallow protopath overwrite by avoiding magic attributes

### DIFF
--- a/src/oset.ts
+++ b/src/oset.ts
@@ -6,6 +6,9 @@ const oset = (obj: any, path: string, value: any) => {
     .split('.');
 
   parts.reduce((prev, curr, i) => {
+    if (prev === Object.prototype) {
+      return prev;
+    }
     if (!(typeof prev[curr] == 'object')) {
       prev[curr] = {};
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -82,6 +82,13 @@ describe('oset.js', () => {
     });
   });
 
+  it('should avoid protopath overwrite', () => {
+    const obj = {};
+    oset(obj, '__proto__.polluted', true);
+    oset(obj, 'constructor.prototype.polluted', true);
+    expect(({} as any).polluted).equal(undefined);
+  })
+
   it('replaces non-object values', () => {
     obj = {
       a: 'lala',


### PR DESCRIPTION
### 📊 Metadata *

`o.set` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-o.set/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns unmodified object, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```javascript
// poc.js
var o = require("o.set")
var obj = {};
console.log("Before: " + {}.polluted)
o(obj, "__proto__.polluted", true)
console.log("After: " + {}.polluted)
```
2. Execute the following commands in the terminal:
```bash
npm i o.set # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: true
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107875498-54d96980-6ee6-11eb-8a65-ac03a15ea47a.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107875467-1348be80-6ee6-11eb-94fb-02abc0bea69f.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/107875692-640ce700-6ee7-11eb-9807-8626bc494051.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1902
